### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/mycargus/rspec-capybara-docker-grid/security/code-scanning/1](https://github.com/mycargus/rspec-capybara-docker-grid/security/code-scanning/1)

In general, the fix is to declare an explicit `permissions` block that grants only the minimal required permissions for the jobs in this workflow. Since this workflow only checks out the repository and runs a build/test script, it likely only needs read access to repository contents. The safest minimal starting point, aligned with the CodeQL recommendation, is `contents: read`.

The single best way to fix this without changing functionality is to add a `permissions` block at the workflow root level (so it applies to all jobs) directly under the `name:` line and before the `on:` block. This keeps the workflow behavior the same while constraining the `GITHUB_TOKEN` to read-only repository contents, which is sufficient for `actions/checkout@v4` and running scripts that only read code. No imports or additional methods are needed, as this is purely a YAML configuration change inside `.github/workflows/ci.yml`.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  after line 1 (`name: CI`) and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
